### PR TITLE
If method passed a complete http query only validate the components that Shopify creates the sig on

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -78,7 +78,7 @@ class ShopifyClient {
 			return false;
 
 		foreach($query as $k => $v) {
-			if($k == 'signature') continue;
+			if($k != 'shop' && $k != 'code' && $k != 'timestamp') continue;
 			$signature[] = $k . '=' . $v;
 		}
 


### PR DESCRIPTION
Most frameworks 'query' object or incoming urls may contain extra data not used in generating a signature. Dump any data not used in the shopify signing process.