### PR TITLE
Update shopify.php - validateSignature requires 'hmac'.

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -78,7 +78,7 @@ class ShopifyClient {
 			return false;
 
 		foreach($query as $k => $v) {
-			if($k != 'shop' && $k != 'code' && $k != 'timestamp') continue;
+			if($k != 'shop' && $k != 'hmac' && $k != 'timestamp') continue;
 			$signature[] = $k . '=' . $v;
 		}
 


### PR DESCRIPTION
validateSignature requires 'hmac' as part of the signature, not 'code'.