### PR TITLE
Use HTTPS for Shopify Authorization

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -16,7 +16,7 @@ class ShopifyClient {
 
 	// Get the URL required to request authorization
 	public function getAuthorizeUrl($scope, $redirect_url='') {
-		$url = "http://{$this->shop_domain}/admin/oauth/authorize?client_id={$this->api_key}&scope=" . urlencode($scope);
+		$url = "https://{$this->shop_domain}/admin/oauth/authorize?client_id={$this->api_key}&scope=" . urlencode($scope);
 		if ($redirect_url != '')
 		{
 			$url .= "&redirect_uri=" . urlencode($redirect_url);


### PR DESCRIPTION
[Shopify's guides](https://help.shopify.com/api/guides/authentication/oauth#asking-for-permission) are pretty clear about specifying HTTPS for authentication URLs. When I attempt to hit HTTP addresses that match this pattern, I'm immediately redirected to the secure version. No sense hitting that auto-redirect.

Thanks for the script. It's saved us a ton of time!
