### PR TITLE
Include state in auth url

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -15,12 +15,20 @@ class ShopifyClient {
 	}
 
 	// Get the URL required to request authorization
-	public function getAuthorizeUrl($scope, $redirect_url='') {
+	public function getAuthorizeUrl($scope, $redirect_url='', $state = null) {
+		
+		if($state === null){
+		    $state = sha1(time());
+		}
+		
 		$url = "https://{$this->shop_domain}/admin/oauth/authorize?client_id={$this->api_key}&scope=" . urlencode($scope);
 		if ($redirect_url != '')
 		{
 			$url .= "&redirect_uri=" . urlencode($redirect_url);
 		}
+		
+		$url .='&state=' urlencode($redirect_url);
+		
 		return $url;
 	}
 
@@ -79,7 +87,7 @@ class ShopifyClient {
 
 		$dataString = array();
 		foreach ($query as $key => $value) {
-			if(!in_array($key, array('shop', 'timestamp', 'code'))) continue;
+			if(!in_array($key, array('shop', 'timestamp', 'code', 'state'))) continue;
 
 			$key = str_replace('=', '%3D', $key);
 			$key = str_replace('&', '%26', $key);

--- a/shopify.php
+++ b/shopify.php
@@ -22,12 +22,11 @@ class ShopifyClient {
 		}
 		
 		$url = "https://{$this->shop_domain}/admin/oauth/authorize?client_id={$this->api_key}&scope=" . urlencode($scope);
+		$url .='&state=' urlencode($state);
 		if ($redirect_url != '')
 		{
 			$url .= "&redirect_uri=" . urlencode($redirect_url);
 		}
-		
-		$url .='&state=' urlencode($redirect_url);
 		
 		return $url;
 	}


### PR DESCRIPTION
It seems like if you follow Shopify OAuth Documentation and include the **state** parameter for verification the **hmac** verification fails on the client server size. My assumption is that Shopify includes **state** in calculation  of the hash

> https://{shop}.myshopify.com/admin/oauth/authorize?client_id={api_key}&scope={scopes}&redirect_uri={redirect_uri}&state={nonce} 
> 
> {nonce} - a randomly selected value provided by your application, which is unique for each authorization request. During the OAuth >callback phase, your application must check that this value matches the one you provided during authorization. This mechanism is >important for the security of your application.

[Shopify docs](https://help.shopify.com/api/guides/authentication/oauth#scopes)
